### PR TITLE
Fix/double logs

### DIFF
--- a/Loggie/Classes/Alamofire/EventMonitor.swift
+++ b/Loggie/Classes/Alamofire/EventMonitor.swift
@@ -17,9 +17,13 @@ public final class EventMonitor: Alamofire.EventMonitor {
 
     public func request(_ request: Request, didGatherMetrics metrics: URLSessionTaskMetrics) {
         /// we're handling only `DataRequest`s for now
-        guard let dataRequest = request as? DataRequest, let urlRequest = dataRequest.request else { return }
-        guard let metric = metrics.transactionMetrics.last else { return }
-        guard let startTime = metric.requestStartDate, let endTime = metric.responseEndDate else { return }
+        guard
+            let dataRequest = request as? DataRequest,
+            let urlRequest = dataRequest.request,
+            let metric = metrics.transactionMetrics.last,
+            let startTime = metric.requestStartDate,
+            let endTime = metric.responseEndDate
+        else { return }
 
         let log = Log(request: urlRequest)
         log.startTime = startTime

--- a/Loggie/Classes/Alamofire/EventMonitor.swift
+++ b/Loggie/Classes/Alamofire/EventMonitor.swift
@@ -18,21 +18,19 @@ public final class EventMonitor: Alamofire.EventMonitor {
     public func request(_ request: Request, didGatherMetrics metrics: URLSessionTaskMetrics) {
         /// we're handling only `DataRequest`s for now
         guard let dataRequest = request as? DataRequest, let urlRequest = dataRequest.request else { return }
+        guard let metric = metrics.transactionMetrics.last else { return }
+        guard let startTime = metric.requestStartDate, let endTime = metric.responseEndDate else { return }
 
-        for metric in metrics.transactionMetrics {
-            guard let startTime = metric.requestStartDate, let endTime = metric.responseEndDate else { return }
+        let log = Log(request: urlRequest)
+        log.startTime = startTime
+        log.endTime = endTime
+        log.data = dataRequest.data
+        log.error = dataRequest.error
+        log.response = metric.response as? HTTPURLResponse
+        // For some reason, the request that is collected only has a handful of headers available. To make this a bit more verbose,
+        // we're attaching headers from the metric which has a lot more information about the request.
+        log.request.headers = metric.request.headers
 
-            let log = Log(request: urlRequest)
-            log.startTime = startTime
-            log.endTime = endTime
-            log.data = dataRequest.data
-            log.error = dataRequest.error
-            log.response = metric.response as? HTTPURLResponse
-            // For some reason, the request that is collected only has a handful of headers available. To make this a bit more verbose,
-            // we're attaching headers from the metric which has a lot more information about the request.
-            log.request.headers = metric.request.headers
-
-            LoggieManager.shared.add(log)
-        }
+        LoggieManager.shared.add(log)
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Loggie
 
 [![Build Status](https://app.bitrise.io/app/f779303cc7c884f6/status.svg?token=9OxOU504sMcEOrzfNcbwvg&branch=master)](https://app.bitrise.io/app/f779303cc7c884f6)
-[![Version](https://img.shields.io/cocoapods/v/Loggie.svg?style=flat)](http://cocoapods.org/pods/Loggie)
-[![License](https://img.shields.io/cocoapods/l/Loggie.svg?style=flat)](http://cocoapods.org/pods/Loggie)
+[![Version](https://img.shields.io/cocoapods/v/Loggie.svg?style=flat)](https://cocoapods.org/pods/Loggie)
+[![License](https://img.shields.io/cocoapods/l/Loggie.svg?style=flat)](https://cocoapods.org/pods/Loggie)
 [![Swift Package Manager](https://img.shields.io/badge/swift%20package%20manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
-[![Platform](https://img.shields.io/cocoapods/p/Loggie.svg?style=flat)](http://cocoapods.org/pods/Loggie)
+[![Platform](https://img.shields.io/cocoapods/p/Loggie.svg?style=flat)](https://cocoapods.org/pods/Loggie)
 
 <p align="center">
     <img src="./Resources/icon.svg" width="300" max-width="50%" alt="Loggie"/>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Loggie
 
 [![Build Status](https://app.bitrise.io/app/f779303cc7c884f6/status.svg?token=9OxOU504sMcEOrzfNcbwvg&branch=master)](https://app.bitrise.io/app/f779303cc7c884f6)
-[![Version](https://img.shields.io/cocoapods/v/icon.svg?style=flat)](https://cocoapods.org/pods/Loggie)
-[![License](https://img.shields.io/cocoapods/l/icon.svg?style=flat)](https://cocoapods.org/pods/Loggie)
+[![Version](https://img.shields.io/cocoapods/v/Loggie)](https://cocoapods.org/pods/Loggie)
+[![License](https://img.shields.io/cocoapods/l/Loggie)](https://cocoapods.org/pods/Loggie)
 [![Swift Package Manager](https://img.shields.io/badge/swift%20package%20manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
-[![Platform](https://img.shields.io/cocoapods/p/icon.svg?style=flat)](https://cocoapods.org/pods/Loggie)
+[![Platform](https://img.shields.io/cocoapods/p/Loggie)](https://cocoapods.org/pods/Loggie)
 
 <p align="center">
     <img src="./Resources/icon.svg" width="300" max-width="50%" alt="Loggie"/>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Loggie
 
 [![Build Status](https://app.bitrise.io/app/f779303cc7c884f6/status.svg?token=9OxOU504sMcEOrzfNcbwvg&branch=master)](https://app.bitrise.io/app/f779303cc7c884f6)
-[![Version](https://img.shields.io/cocoapods/v/Loggie)](https://cocoapods.org/pods/Loggie)
+[![Version](https://img.shields.io/cocoapods/v/Loggie)](https://img.shields.io/cocoapods/v/Loggie)
 [![License](https://img.shields.io/cocoapods/l/Loggie)](https://cocoapods.org/pods/Loggie)
 [![Swift Package Manager](https://img.shields.io/badge/swift%20package%20manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![Platform](https://img.shields.io/cocoapods/p/Loggie)](https://cocoapods.org/pods/Loggie)
 
+https://img.shields.io/cocoapods/v/Loggie
 <p align="center">
     <img src="./Resources/icon.svg" width="300" max-width="50%" alt="Loggie"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Loggie
 
 [![Build Status](https://app.bitrise.io/app/f779303cc7c884f6/status.svg?token=9OxOU504sMcEOrzfNcbwvg&branch=master)](https://app.bitrise.io/app/f779303cc7c884f6)
-[![Version](https://img.shields.io/cocoapods/v/Loggie)](https://img.shields.io/cocoapods/v/Loggie)
+[![Version](https://img.shields.io/cocoapods/v/Loggie)](https://cocoapods.org/pods/Loggie)
 [![License](https://img.shields.io/cocoapods/l/Loggie)](https://cocoapods.org/pods/Loggie)
 [![Swift Package Manager](https://img.shields.io/badge/swift%20package%20manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![Platform](https://img.shields.io/cocoapods/p/Loggie)](https://cocoapods.org/pods/Loggie)
@@ -12,7 +12,7 @@ https://img.shields.io/cocoapods/v/Loggie
 </p>
 
 ## About
-
+![Cocoapods](https://img.shields.io/cocoapods/v/Loggie)
 
 **Loggie** is a simple in-app network logging library that gives the developers and the QA testers a possibility to log network. The library is handy for easily accessible list of network trafic.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # Loggie
 
 [![Build Status](https://app.bitrise.io/app/f779303cc7c884f6/status.svg?token=9OxOU504sMcEOrzfNcbwvg&branch=master)](https://app.bitrise.io/app/f779303cc7c884f6)
-[![Version](https://img.shields.io/cocoapods/v/Loggie)](https://cocoapods.org/pods/Loggie)
-[![License](https://img.shields.io/cocoapods/l/Loggie)](https://cocoapods.org/pods/Loggie)
+[![Version](https://img.shields.io/cocoapods/v/Loggie.svg?style=flat)](http://cocoapods.org/pods/Loggie)
+[![License](https://img.shields.io/cocoapods/l/Loggie.svg?style=flat)](http://cocoapods.org/pods/Loggie)
 [![Swift Package Manager](https://img.shields.io/badge/swift%20package%20manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
-[![Platform](https://img.shields.io/cocoapods/p/Loggie)](https://cocoapods.org/pods/Loggie)
+[![Platform](https://img.shields.io/cocoapods/p/Loggie.svg?style=flat)](http://cocoapods.org/pods/Loggie)
 
-https://img.shields.io/cocoapods/v/Loggie
 <p align="center">
     <img src="./Resources/icon.svg" width="300" max-width="50%" alt="Loggie"/>
 </p>
 
 ## About
-![Cocoapods](https://img.shields.io/cocoapods/v/Loggie)
 
 **Loggie** is a simple in-app network logging library that gives the developers and the QA testers a possibility to log network. The library is handy for easily accessible list of network trafic.
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Loggie
 
 [![Build Status](https://app.bitrise.io/app/f779303cc7c884f6/status.svg?token=9OxOU504sMcEOrzfNcbwvg&branch=master)](https://app.bitrise.io/app/f779303cc7c884f6)
-[![Version](https://img.shields.io/cocoapods/v/Loggie.svg?style=flat)](https://cocoapods.org/pods/Loggie)
-[![License](https://img.shields.io/cocoapods/l/Loggie.svg?style=flat)](https://cocoapods.org/pods/Loggie)
+[![Version](https://img.shields.io/cocoapods/v/icon.svg?style=flat)](https://cocoapods.org/pods/Loggie)
+[![License](https://img.shields.io/cocoapods/l/icon.svg?style=flat)](https://cocoapods.org/pods/Loggie)
 [![Swift Package Manager](https://img.shields.io/badge/swift%20package%20manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
-[![Platform](https://img.shields.io/cocoapods/p/Loggie.svg?style=flat)](https://cocoapods.org/pods/Loggie)
+[![Platform](https://img.shields.io/cocoapods/p/icon.svg?style=flat)](https://cocoapods.org/pods/Loggie)
 
 <p align="center">
     <img src="./Resources/icon.svg" width="300" max-width="50%" alt="Loggie"/>
 </p>
 
 ## About
+
 
 **Loggie** is a simple in-app network logging library that gives the developers and the QA testers a possibility to log network. The library is handy for easily accessible list of network trafic.
 
@@ -22,7 +23,7 @@
 ## Installation
 
 ### CocoaPods
-Loggie is available through [CocoaPods](http://cocoapods.org). To install
+Loggie is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby


### PR DESCRIPTION
Hi reviewers, 

I noticed an issue with the new (2.4.1.) version of Loggie. The issue was that sometimes API request would log twice.
Here is an image of that problem:
![Screenshot 2023-03-27 at 18 12 49](https://user-images.githubusercontent.com/37837673/228002031-41fe2c26-571a-4c9d-8181-7aae56b4617a.png)

To fix this, I changed logging in `EventMonitor` class to 


```swift
    public func request(_ request: Request, didGatherMetrics metrics: URLSessionTaskMetrics) {
        /// we're handling only `DataRequest`s for now
        guard let dataRequest = request as? DataRequest, let urlRequest = dataRequest.request else { return }
        guard let metric = metrics.transactionMetrics.first else { return }
        guard let startTime = metric.requestStartDate, let endTime = metric.responseEndDate else { return }

        let log = Log(request: urlRequest)
        log.startTime = startTime
        log.endTime = endTime
        log.data = dataRequest.data
        log.error = dataRequest.error
        log.response = metric.response as? HTTPURLResponse
        // For some reason, the request that is collected only has a handful of headers available. To make this a bit more verbose,
        // we're attaching headers from the metric which has a lot more information about the request.
        log.request.headers = metric.request.headers

        LoggieManager.shared.add(log)
    }
```

This solved the double logs issue, but introduced a new one: API call time was not calculated properly. Here is the proof:
![Screenshot 2023-03-27 at 18 14 12](https://user-images.githubusercontent.com/37837673/228002822-515c5e38-19ba-4c02-827b-3969f5b84fa7.png)

Finally, changing from 

```swift
        guard let metric = metrics.transactionMetrics.first else { return }
```

to

```swift
        guard let metric = metrics.transactionMetrics.last else { return }
```

fixes the issue. 

After these changes API call logging looks like it looked before:
![Screenshot 2023-03-27 at 18 16 01](https://user-images.githubusercontent.com/37837673/228003183-7bcd2ce9-e4d1-488b-82e4-bce205601273.png)

