### PR TITLE
Fix/dispatch to main thread when updating log list

### DIFF
--- a/Examples/SwiftPM/Loggie.xcodeproj/project.pbxproj
+++ b/Examples/SwiftPM/Loggie.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6073E0032543463300AD06DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6073E0022543463300AD06DA /* Assets.xcassets */; };
 		6073E0062543463300AD06DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6073E0042543463300AD06DA /* LaunchScreen.storyboard */; };
 		60C28EE1254861F200979EBE /* BaseExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C28EE0254861F200979EBE /* BaseExampleViewController.swift */; };
+		A49ADF862A4C097C0056545F /* Loggie in Frameworks */ = {isa = PBXBuildFile; productRef = A49ADF852A4C097C0056545F /* Loggie */; };
 		C1D615A328F6D631006C7EA1 /* URLSessionExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D615A128F6D631006C7EA1 /* URLSessionExampleViewController.swift */; };
 		C1D615A428F6D631006C7EA1 /* AlamofireExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D615A228F6D631006C7EA1 /* AlamofireExampleViewController.swift */; };
 		EED4EAC12A6FC96400E24E9A /* Loggie in Frameworks */ = {isa = PBXBuildFile; productRef = EED4EAC02A6FC96400E24E9A /* Loggie */; };
@@ -37,7 +38,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EED4EAC12A6FC96400E24E9A /* Loggie in Frameworks */,
+				A49ADF862A4C097C0056545F /* Loggie in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,7 +111,7 @@
 			);
 			name = LoggieExample;
 			packageProductDependencies = (
-				EED4EAC02A6FC96400E24E9A /* Loggie */,
+				A49ADF852A4C097C0056545F /* Loggie */,
 			);
 			productName = iOSExample;
 			productReference = 6073DFF72543463200AD06DA /* LoggieExample.app */;
@@ -140,6 +141,7 @@
 			);
 			mainGroup = 60345CDA254306DB00E24BD4;
 			packageReferences = (
+				A49ADF842A4C097C0056545F /* XCRemoteSwiftPackageReference "iOS-Loggie" */,
 			);
 			productRefGroup = 60345CE5254306DB00E24BD4 /* Products */;
 			projectDirPath = "";
@@ -379,9 +381,21 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		A49ADF842A4C097C0056545F /* XCRemoteSwiftPackageReference "iOS-Loggie" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/infinum/iOS-Loggie";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
-		EED4EAC02A6FC96400E24E9A /* Loggie */ = {
+		A49ADF852A4C097C0056545F /* Loggie */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = A49ADF842A4C097C0056545F /* XCRemoteSwiftPackageReference "iOS-Loggie" */;
 			productName = Loggie;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Examples/SwiftPM/Loggie.xcodeproj/project.pbxproj
+++ b/Examples/SwiftPM/Loggie.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		6073E0052543463300AD06DA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6073E0072543463300AD06DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		60C28EE0254861F200979EBE /* BaseExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseExampleViewController.swift; sourceTree = "<group>"; };
+		A49ADF872A4C0A1F0056545F /* iOS-Loggie */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "iOS-Loggie"; path = ../..; sourceTree = "<group>"; };
 		C1D615A128F6D631006C7EA1 /* URLSessionExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionExampleViewController.swift; sourceTree = "<group>"; };
 		C1D615A228F6D631006C7EA1 /* AlamofireExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlamofireExampleViewController.swift; sourceTree = "<group>"; };
 		EED4EABE2A6FC95A00E24E9A /* iOS-Loggie */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "iOS-Loggie"; path = ../..; sourceTree = "<group>"; };

--- a/Loggie/Classes/Core/LogList/LogListTableViewController.swift
+++ b/Loggie/Classes/Core/LogList/LogListTableViewController.swift
@@ -146,7 +146,12 @@ extension LogListTableViewController {
     }
 
     @objc private func loggieDidUpdateLogs() {
-        updateLogs()
+        // This function is not called from the main thread.
+        // because of that we need to Dispatch here to update the UI on the main thread.
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.updateLogs()
+        }
     }
 
     @objc private func closeButtonActionHandler() {

--- a/Loggie/Classes/Core/LoggieManager.swift
+++ b/Loggie/Classes/Core/LoggieManager.swift
@@ -40,7 +40,7 @@ public final class LoggieManager: NSObject, LogsDataSourceDelegate {
     // MARK: - Properties
     
     /// A **serial** queue, on which Loggie is appending new logs & posting a notification that `logs` have changed.
-    private let logsHandlingQueue: DispatchQueue = .init(label: "com.infinum.loggie-logs-handling-queue")
+    let logsHandlingQueue: DispatchQueue = .init(label: "com.infinum.loggie-logs-handling-queue")
     
     /// An instance of `URLSession` which Loggie is using if there's no delegate to provide his own session.
     ///
@@ -92,7 +92,7 @@ public final class LoggieManager: NSObject, LogsDataSourceDelegate {
     
     public func add(_ log: Log) {
         // Avoid changing logs array from multiple threads (race condition)
-        logsHandlingQueue.async(flags: .barrier) { [weak self] in
+        logsHandlingQueue.async { [weak self] in
             guard let self = self else { return }
             self.logs.append(log)
             NotificationCenter.default.post(name: .LoggieDidUpdateLogs, object: self.logs)
@@ -101,7 +101,7 @@ public final class LoggieManager: NSObject, LogsDataSourceDelegate {
 
     func clearLogs() {
         // Avoid changing logs array from multiple threads (race condition)
-        logsHandlingQueue.async(flags: .barrier) { [weak self] in
+        logsHandlingQueue.async { [weak self] in
             guard let self = self else { return }
             self.logs = []
         }


### PR DESCRIPTION
This PR fixes crash that happens when `LogListTableViewController` is on screen and new log gets added to the list.

For example this can happen in the following case.
1. make API request
2. open LogList before API response is received
3. API response is received and the app crashes because we update UI on a background thread.

To fix this we need to ensure that updating UI happens on a mainThread. This is done here:

```swift
        LoggieManager.shared.logsHandlingQueue.async {
            DispatchQueue.main.sync { [weak self] in
                guard let self = self else { return }
                self.updateLogs()
            }
        }
```  

The reason I used combination of `LoggieManager.shared.logsHandlingQueue.async` and  `DispatchQueue.main.sync` is because `updateLogs` function reads from `LoggieManager.logs` array and that property is safe to access only from that queue.
 
In addition I removed `.barrier` flag since that flag does not have effect on serialQueues, and `logsHandlingQueue` is defined as a serial queue. (https://developer.apple.com/documentation/dispatch/dispatchworkitemflags/1780674-barrier)
