### PR TITLE
Loggie deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Loggie is deprecated
-
-We suggest to migrate to [Pulse](https://github.com/kean/pulse). Pulse is more powerful and flexible then Loggie.
-
 # Loggie
+
+> __IMPORTANT NOTE:__
+> 
+> Loggie is __deprecated__ and __no longer maintained__. We suggest migrating to [Pulse](https://github.com/kean/pulse) as an alternative. Pulse is more powerful and flexible then Loggie.
 
 [![Build Status](https://github.com/infinum/ios-loggie/actions/workflows/ci.yml/badge.svg)](https://github.com/infinum/ios-loggie/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/cocoapods/v/Loggie.svg?style=flat)](http://cocoapods.org/pods/Loggie)


### PR DESCRIPTION
The release `2.4.3` will be the latest version of Loggie.

We decided to sunset this library, with a recommendation to use `Pulse` for future network logging.